### PR TITLE
Remove unrequired dependencies

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,11 +27,9 @@ requirements:
   run:
     - python >=${{ python_min }}
     - array-api-extra >=0.9.0
-    - array-api-strict >=2.0
     - healpix >=2022.11.1
     - healpy >=1.15.0
     - transformcl >=2022.8.9
-    - typing-extensions >=4.13.2
 
 tests:
   - python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: f7b06bb3e8ca9dcd314e322a145873dc4df67811ec1f0015d74c5a933beb4c35
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The following dependencies are no longer required: `array-api-strict`, `typing-extensions`. This PR removes them.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
